### PR TITLE
Fix alpha blending (and remove dead shadow code)

### DIFF
--- a/Assets/OpenRelativity/Shaders/Lit/relativityLitStandard.shader
+++ b/Assets/OpenRelativity/Shaders/Lit/relativityLitStandard.shader
@@ -103,28 +103,7 @@ Shader "Relativity/Lit/Standard" {
             // TODO: Prettify the syntax of this section.
 #if LIGHTMAP_ON
 			float2 lightmapUV : TEXCOORD3; //Lightmap TEXCOORD
-    #if SHADOW_OR_SPOT
-			float4 ambient : TEXCOORD4;
-			SHADOW_COORDS(5)
-	    #if FORWARD_FOG
-			float4 pos3 : TEXCOORD6; //Untransformed position in world, relative to player position in world
-		    #if _EMISSION
-			float2 emissionUV : TEXCOORD7; //EmisionMap TEXCOORD
-			    #if defined(POINT)
-			float4 lstv : TEXCOORD8;
-			    #endif
-		    #elif defined(POINT) || SPECULAR
-			float4 lstv : TEXCOORD9;
-		    #endif
-	    #elif _EMISSION
-			float2 emissionUV : TEXCOORD6; //EmisionMap TEXCOORD
-		    #if defined(POINT) || SPECULAR
-			float4 lstv : TEXCOORD7;
-		    #endif
-	    #elif defined(POINT) || SPECULAR
-			float4 lstv : TEXCOORD6;
-	    #endif
-    #elif FORWARD_FOG
+    #if FORWARD_FOG
 			float4 pos3 : TEXCOORD4; //Untransformed position in world, relative to player position in world
 	    #if _EMISSION
 			float2 emissionUV : TEXCOORD5; //EmisionMap TEXCOORD
@@ -145,24 +124,23 @@ Shader "Relativity/Lit/Standard" {
 #else
 	#if SHADOW_OR_SPOT
 			float4 ambient : TEXCOORD3;
-			SHADOW_COORDS(4)
 	    #if FORWARD_FOG
-			float4 pos3 : TEXCOORD5; //Untransformed position in world, relative to player position in world
+			float4 pos3 : TEXCOORD4; //Untransformed position in world, relative to player position in world
 		    #if _EMISSION
-			float2 emissionUV : TEXCOORD6; //EmisionMap TEXCOORD
+			float2 emissionUV : TEXCOORD5; //EmisionMap TEXCOORD
 			    #if defined(POINT)
-			float4 lstv : TEXCOORD7;
+			float4 lstv : TEXCOORD6;
 			    #endif
 		    #elif defined(POINT) || SPECULAR
-			float4 lstv : TEXCOORD8;
+			float4 lstv : TEXCOORD7;
 		    #endif
 	    #elif _EMISSION
-			float2 emissionUV : TEXCOORD5; //EmisionMap TEXCOORD
+			float2 emissionUV : TEXCOORD4; //EmisionMap TEXCOORD
 		    #if defined(POINT) || SPECULAR
-			float4 lstv : TEXCOORD6;
+			float4 lstv : TEXCOORD5;
 		    #endif
 	    #elif defined(POINT) || SPECULAR
-			float4 lstv : TEXCOORD5;
+			float4 lstv : TEXCOORD4;
 	    #endif
     #elif FORWARD_FOG
 			float4 pos3 : TEXCOORD3; //Untransformed position in world, relative to player position in world
@@ -597,10 +575,6 @@ Shader "Relativity/Lit/Standard" {
 				o.diff.rgb += diffuseReflection;
 			}
 
-	#if SHADOW_OR_SPOT
-			TRANSFER_SHADOW(o)
-	#endif
-
 #else
 			o.diff = 0;
 
@@ -765,8 +739,7 @@ Shader "Relativity/Lit/Standard" {
 
 			//Apply lighting:
 #if SHADOW_OR_SPOT
-			fixed shadow = SHADOW_ATTENUATION(i);
-			rgbFinal *= (i.diff * shadow + i.ambient);
+			rgbFinal *= (i.diff + i.ambient);
 #else
 			rgbFinal *= i.diff;
 #endif
@@ -855,6 +828,8 @@ Shader "Relativity/Lit/Standard" {
 		ENDCG
 
 		Subshader {
+
+			Tags{ "RenderType" = "Transparent" "Queue" = "Transparent" }
 
 			Pass{
 				//Shader properties, for things such as transparency

--- a/Assets/OpenRelativity/Shaders/Unlit/relativityAccel.shader
+++ b/Assets/OpenRelativity/Shaders/Unlit/relativityAccel.shader
@@ -394,31 +394,31 @@ Shader "Relativity/Unlit/ColorLorentz"
 
 			Subshader {
 
-			Pass{
-				//Shader properties, for things such as transparency
-				ZWrite On
-				ZTest LEqual
-				Fog { Mode off } //Fog does not shift properly and there is no way to do so with this fog
-				Tags {"RenderType" = "Transparent" "Queue" = "Transparent"}
+				Tags{ "RenderType" = "Transparent" "Queue" = "Transparent" }
 
-				AlphaTest Greater[_Cutoff]
-				Blend SrcAlpha OneMinusSrcAlpha
+				Pass{
+					//Shader properties, for things such as transparency
+					Fog { Mode off } //Fog does not shift properly and there is no way to do so with this fog
+					ZWrite On
+					ZTest LEqual
+					AlphaTest Greater[_Cutoff]
+					Blend SrcAlpha OneMinusSrcAlpha
 
-				CGPROGRAM
+					CGPROGRAM
 
-				#pragma fragmentoption ARB_precision_hint_nicest
+					#pragma fragmentoption ARB_precision_hint_nicest
 
-				#pragma shader_feature DOPPLER_SHIFT
-				#pragma shader_feature UV_IR_TEXTURES
-				#pragma shader_feature DOPPLER_MIX
+					#pragma shader_feature DOPPLER_SHIFT
+					#pragma shader_feature UV_IR_TEXTURES
+					#pragma shader_feature DOPPLER_MIX
 
-				#pragma vertex vert
-				#pragma fragment frag
-				#pragma target 3.0
+					#pragma vertex vert
+					#pragma fragment frag
+					#pragma target 3.0
 
-				ENDCG
+					ENDCG
+				}
 			}
-		}
 
 		CustomEditor "AcceleratedRelativityGUI"
 

--- a/Assets/OpenRelativity/Shaders/Unlit/relativityColorOnly.shader
+++ b/Assets/OpenRelativity/Shaders/Unlit/relativityColorOnly.shader
@@ -303,29 +303,30 @@ Shader "Relativity/Unlit/ColorOnly"
 
 		Subshader {
 
-		Pass{
-			//Shader properties, for things such as transparency
-			Cull Off ZWrite On
-			ZTest LEqual
-			Fog{ Mode off } //Fog does not shift properly and there is no way to do so with this fog
 			Tags{ "RenderType" = "Transparent" "Queue" = "Transparent" }
 
-			AlphaTest Greater[_Cutoff]
-			Blend SrcAlpha OneMinusSrcAlpha
+			Pass{
+				//Shader properties, for things such as transparency
+				Cull Off ZWrite On
+				ZTest LEqual
+				Fog{ Mode off } //Fog does not shift properly and there is no way to do so with this fog
 
-			CGPROGRAM
+				AlphaTest Greater[_Cutoff]
+				Blend SrcAlpha OneMinusSrcAlpha
 
-			#pragma fragmentoption ARB_precision_hint_nicest
+				CGPROGRAM
 
-			#pragma shader_feature UV_IR_TEXTURES
-			#pragma shader_feature DOPPLER_MIX
+				#pragma fragmentoption ARB_precision_hint_nicest
 
-			#pragma vertex vert
-			#pragma fragment frag
-			#pragma target 3.0
+				#pragma shader_feature UV_IR_TEXTURES
+				#pragma shader_feature DOPPLER_MIX
 
-			ENDCG
-		}
+				#pragma vertex vert
+				#pragma fragment frag
+				#pragma target 3.0
+
+				ENDCG
+			}
 	}
 
 	CustomEditor "ColorOnlyRelativityGUI"


### PR DESCRIPTION
This addresses #34, fixing the bug in the alpha channel. (Certain tags needed to be moved "subshader" level, up from "pass.")