### PR TITLE
Bug: compose `ConformalMap` metric with player Rindler factor

### DIFF
--- a/Assets/OpenRelativity/Scripts/ConformalMaps/ConformalMap.cs
+++ b/Assets/OpenRelativity/Scripts/ConformalMaps/ConformalMap.cs
@@ -11,7 +11,7 @@ namespace OpenRelativity.ConformalMaps
     public abstract class ConformalMap : RelativisticBehavior
     {
         // TO DEFINE A CONFORMAL MAP ON A GENERAL RIEMANNIAN BACKGROUND GEOMETRY,
-        // Define the 3 following functions...
+        // Define the 4 following functions...
 
         // Given an input Unity world coordinate 3-position and intrinsic rotation, tell me how both comove in free fall, over a proper time interval.
         abstract public Comovement ComoveOptical(float properTDiff, Vector3 piw, Quaternion riw);
@@ -21,6 +21,12 @@ namespace OpenRelativity.ConformalMaps
 
         // Given an input Unity world coordinate 3-position, tell me the velocity of free fall, i.e. at 0 (gravitational + proper) acceleration.
         abstract public Vector3 GetFreeFallVelocity(Vector3 piw);
+
+        // Given an input unity world coordinate 3-position, tell me the metric, as seen by a static and stationary observer at infinity.
+        virtual public Matrix4x4 GetMetric(Vector3 piw)
+        {
+            return SRelativityUtil.GetRindlerMetric(piw, GetRindlerAcceleration(piw), Vector3.zero);
+        }
 
         // (A "conformal map" LOOKS like flat space LOCALLY for "matter fields," but "conforms" to an underlying curved space-time manifold.)
         // (... In other words, Euclidean geometry for matter fields, warped to "conform" to the true underlying subtle or gross curvature of space-time.)

--- a/Assets/OpenRelativity/Scripts/ConformalMaps/Minkowski.cs
+++ b/Assets/OpenRelativity/Scripts/ConformalMaps/Minkowski.cs
@@ -24,5 +24,15 @@ namespace OpenRelativity.ConformalMaps
         {
             return Vector3.zero;
         }
+
+        public override Matrix4x4 GetMetric(Vector3 piw)
+        {
+            return new Matrix4x4(
+                new Vector4(-1, 0, 0, 0),
+                new Vector4(0, -1, 0, 0),
+                new Vector4(0, 0, -1, 0),
+                new Vector4(0, 0, 0, 1)
+            );
+        }
     }
 }

--- a/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
+++ b/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
@@ -116,7 +116,7 @@ namespace OpenRelativity.Objects
             else
             {
                 Matrix4x4 intrinsicMetric = state.conformalMap.GetMetric(piw);
-                return intrinsicMetric.inverse * metric * intrinsicMetric;
+                return intrinsicMetric * metric * intrinsicMetric.inverse;
             }
         }
 

--- a/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
+++ b/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
@@ -107,7 +107,17 @@ namespace OpenRelativity.Objects
                 return updateMetric;
             }
 
-            return SRelativityUtil.GetRindlerMetric(piw);
+            Matrix4x4 metric = SRelativityUtil.GetRindlerMetric(piw);
+
+            if (state.conformalMap == null)
+            {
+                return metric;
+            }
+            else
+            {
+                Matrix4x4 intrinsicMetric = state.conformalMap.GetMetric(piw);
+                return intrinsicMetric.inverse * metric * intrinsicMetric;
+            }
         }
 
         public Vector4 Get4Velocity()


### PR DESCRIPTION
(See also issue #58.) Here's the reasoning behind this change:

Firstly, grant me that we can calculate the _local numerical_ metric, at a specific point, as seen by a static and stationary observer at infinity, if we have the apparent gravitational _acceleration_ at this point for these preconditions, _due to assumption of Einstein equivalence principle_. (I won't argue this very hard, right now, but the point is that "a gravitational field is _locally_ indistinguishable from a uniform acceleration.)

By whatever means, say we simply have the metric, as seen by such an observer. Then, the player perspective is _embedded_ in the curved space defined by this metric. Then, to get the metric _including the player's perspective_...
1. We start embedded in the metric, at the position of the `RelativisticObject`.
2. We reverse this embedding, by multiplying by the _inverse_ metric.
3. We can now apply the player-perspective Rindler-like deformation of the metric.
4. We re-apply the _original_ embedding, by multiplying again the metric.